### PR TITLE
Fix issue with relative paths and file.base

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function () {
         if (err) return this.emit('error', err)
 
         this.push(new File({
+          base: file.base,
           path: path,
           contents: buffer
         }))


### PR DESCRIPTION
Without the correct file base gulp.dest() calculates wrong destination paths.

Reproduction:
`/a/source/directory/file.tar.gz`
`/a/workingdir/Gulpfile.js`

When using the following task
`gulp.src('/a/source/directory/*.gz').pipe(gunzip()).pipe(gulp.dest('dest'))`
I expect the resulting .tar file to be in `/a/workingdir/dest/file.tar`.

Instead it is stored in `/a/workingdir/source/directory/file.tar`.

This PR fixes this issue.